### PR TITLE
Add BaseUrl support for custom Bot API server

### DIFF
--- a/src/Insight.TelegramBot.DependencyInjection/Builders/TelegramBotClientBuilder.cs
+++ b/src/Insight.TelegramBot.DependencyInjection/Builders/TelegramBotClientBuilder.cs
@@ -59,14 +59,22 @@ public sealed class TelegramBotClientBuilder
         if (_httpClientFactory == null)
         {
             descriptor = new ServiceDescriptor(typeof(ITelegramBotClient),
-                ctx => new TelegramBotClient(ctx.GetRequiredService<IOptions<TelegramBotOptions>>().Value.Token),
+                ctx =>
+                {
+                    var options = ctx.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
+                    return new TelegramBotClient(new TelegramBotClientOptions(options.Token, options.BaseUrl));
+                },
                 _serviceLifetime);
         }
         else
         {
             descriptor = new ServiceDescriptor(typeof(ITelegramBotClient),
-                ctx => new TelegramBotClient(ctx.GetRequiredService<IOptions<TelegramBotOptions>>().Value.Token,
-                    _httpClientFactory.Invoke(ctx)),
+                ctx =>
+                {
+                    var options = ctx.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
+                    return new TelegramBotClient(new TelegramBotClientOptions(options.Token, options.BaseUrl),
+                        _httpClientFactory.Invoke(ctx));
+                },
                 _serviceLifetime);
         }
 

--- a/src/Insight.TelegramBot.DependencyInjection/Builders/TelegramBotOptionsBuilder.cs
+++ b/src/Insight.TelegramBot.DependencyInjection/Builders/TelegramBotOptionsBuilder.cs
@@ -21,6 +21,7 @@ public sealed class TelegramBotOptionsBuilder : OptionsBuilderBase<TelegramBotOp
         Services.Configure<TelegramBotOptions>(opt =>
         {
             opt.Token = options.Token;
+            opt.BaseUrl = options.BaseUrl;
         });
         
         OptionsConfigured = true;

--- a/src/Insight.TelegramBot.DependencyInjection/TelegramBotOptions.cs
+++ b/src/Insight.TelegramBot.DependencyInjection/TelegramBotOptions.cs
@@ -2,5 +2,7 @@ namespace Insight.TelegramBot.DependencyInjection;
 
 public sealed class TelegramBotOptions
 {
-    public string Token { get; set; }
+    public string Token { get; set; } = null!;
+
+    public string? BaseUrl { get; set; }
 }

--- a/tests/Insight.TelegramBot.Tests/Insight.TelegramBot.Tests.csproj
+++ b/tests/Insight.TelegramBot.Tests/Insight.TelegramBot.Tests.csproj
@@ -22,6 +22,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\samples\Insight.TelegramBot.Samples.Handling\Insight.TelegramBot.Samples.Handling.csproj" />
         <ProjectReference Include="..\..\src\Insight.TelegramBot\Insight.TelegramBot.csproj" />
+        <ProjectReference Include="..\..\src\Insight.TelegramBot.DependencyInjection\Insight.TelegramBot.DependencyInjection.csproj" />
         <ProjectReference Include="..\Insight.TelegramBot.Testing\Insight.TelegramBot.Testing.csproj" />
     </ItemGroup>
 

--- a/tests/Insight.TelegramBot.Tests/TelegramBotClientBuilderTests.cs
+++ b/tests/Insight.TelegramBot.Tests/TelegramBotClientBuilderTests.cs
@@ -1,0 +1,49 @@
+using Insight.TelegramBot.DependencyInjection;
+using Insight.TelegramBot.DependencyInjection.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Telegram.Bot;
+using Xunit;
+
+namespace Insight.TelegramBot.Tests;
+
+public class TelegramBotClientBuilderTests
+{
+    // Token format: {botId}:{secret} — no real network calls are made during construction
+    private const string TestToken = "1234567890:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw";
+
+    [Fact]
+    public void AddTelegramBot_WithoutBaseUrl_RegistersClientWithDefaultApiServer()
+    {
+        var services = new ServiceCollection();
+        services.AddTelegramBot(b =>
+        {
+            b.WithOptions(o => o.FromValue(new TelegramBotOptions { Token = TestToken }));
+            b.WithTelegramBotClient(_ => { });
+        });
+
+        var client = services.BuildServiceProvider().GetRequiredService<ITelegramBotClient>();
+
+        Assert.False(client.LocalBotServer);
+    }
+
+    [Fact]
+    public void AddTelegramBot_WithBaseUrl_RegistersClientWithCustomApiServer()
+    {
+        const string customBaseUrl = "http://localhost:8081";
+
+        var services = new ServiceCollection();
+        services.AddTelegramBot(b =>
+        {
+            b.WithOptions(o => o.FromValue(new TelegramBotOptions
+            {
+                Token = TestToken,
+                BaseUrl = customBaseUrl
+            }));
+            b.WithTelegramBotClient(_ => { });
+        });
+
+        var client = services.BuildServiceProvider().GetRequiredService<ITelegramBotClient>();
+
+        Assert.True(client.LocalBotServer);
+    }
+}


### PR DESCRIPTION
Added argument to TelegramBotOptionsBuilder to pass through custom telegram api url.